### PR TITLE
Issue 5: checkhost command does not exist in libressl. 

### DIFF
--- a/ssl/ssl.sh
+++ b/ssl/ssl.sh
@@ -79,11 +79,7 @@ updateall()
 {
     [[ -f ca-key.pem ]] || genrootca  
     [[ -f key.pem ]] || genprivkey
-    if [[ -f cert.pem ]]; then
-        (openssl x509 -in cert.pem -checkhost "$CN" -noout | grep "does match certificate") || gencert
-    else
-        gencert
-    fi
+    gencert
     verifycert
 }
 


### PR DESCRIPTION
Remove this check and regenerate unconditionally the certificate in zero-conf mode. It has no side-effect.