### PR TITLE
Issue 10: Introduce management APIs

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,79 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, PartialEq, Default, Clone, Deserialize, Serialize)]
+pub struct GetParameterNames {
+    pub name: String,
+    pub next_level: bool,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Deserialize, Serialize)]
+pub struct GetParameterNamesResponse {
+    pub name: String,
+    pub writable: bool,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Deserialize, Serialize)]
+pub struct GetParameterValues {
+    pub r#type: String,
+    pub name: String,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Deserialize, Serialize)]
+pub struct GetParameterValuesResponse {
+    pub r#type: String,
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Deserialize, Serialize)]
+pub struct SetParameterValues {
+    pub r#type: String,
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Deserialize, Serialize)]
+pub struct SetParameterValuesResponse {
+    pub status: bool,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Deserialize, Serialize)]
+pub struct Upgrade {
+    pub file_name: String,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Deserialize, Serialize)]
+pub struct UpgradeResponse {
+    pub status: bool,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Deserialize, Serialize)]
+pub struct ErrorResponse {
+    pub description: String,
+}
+
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+pub enum Command {
+    GetParameterNames(GetParameterNames),
+    GetParameterValues(Vec<GetParameterValues>),
+    SetParameterValues(Vec<SetParameterValues>),
+    Upgrade(Upgrade),
+    List(),
+}
+
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+pub struct Request {
+    #[serde(default)]
+    pub serial_number: String,
+    pub command: Command,
+}
+
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+pub enum Response {
+    GetParameterNames(Vec<GetParameterNamesResponse>),
+    GetParameterValues(Vec<GetParameterValuesResponse>),
+    SetParameterValues(SetParameterValuesResponse),
+    Upgrade(UpgradeResponse),
+    Error(ErrorResponse),
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 mod acs;
+mod api;
 mod db;
 mod mng;
 mod session;


### PR DESCRIPTION
I would propose to have well defined management APIs to be used for both frontend and cli.

I imagine than it could be used like this:
```
curl 127.0.0.1:8000/api -d '"Request": {
  "serial_number": "CPE1234",
  "command": XXXX
}'
-----server_response------
"Response": YYYY
```

Let me know if it's okay for you or if you see it differently.