### PR TITLE
Add monitor command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -760,9 +760,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "wasi",
@@ -989,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1328,6 +1328,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,11 +1474,10 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes",
  "libc",
@@ -1477,16 +1486,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.5",
  "tokio-macros",
  "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/acscli.rs"
 
 [dependencies]
 hyper = { version = "1.0.0-rc.4", features = ["full"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.35.0", features = ["full"] }
 tokio-native-tls = "0.3.1"
 pin-project-lite = "0.2.10"
 h2 = "0.3.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acsrs"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 description = "A simple ACS written in rust"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ acscli is an interactive UNIX cli for ACSRS
 ## Availables command when disconnected:
  - ls: List connected CPEs to this ACS
  - cd|connect [SN] : Connect to CPE specified by this Serial Number
+ - monitor : Monitor all Inform messages received by ACS
 
 ## Availables command when connected to a CPE:
  - disconnect :  Disconnect from the current CPE

--- a/src/api.rs
+++ b/src/api.rs
@@ -73,6 +73,42 @@ pub struct CPE {
     pub password: String,
 }
 
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+pub enum Event {
+    Boostrap,
+    Boot,
+    Periodic,
+    Scheduled,
+    ValueChange,
+    Kicked,
+    ConnectionRequest,
+    TransferComplete,
+    DiagnosticsComplete,
+    RequestDownload,
+    AutonomousTransferComplete,
+    MReboot,
+    MScheduleInform,
+    MDownload,
+    MUpload,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Deserialize, Serialize)]
+pub struct InformParameter {
+    pub r#type: String,
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Deserialize, Serialize)]
+pub struct Inform {
+    pub manufacturer: String,
+    pub oui: String,
+    pub product_class: String,
+    pub serial_number: String,
+    pub events: Vec<Event>,
+    pub parameters: Vec<InformParameter>,
+}
+
 #[derive(Debug, PartialEq, Default, Clone, Deserialize, Serialize)]
 pub struct ErrorResponse {
     pub status: u16,
@@ -88,6 +124,7 @@ pub enum Command {
     DeleteObject(DeleteObject),
     Upgrade(Upgrade),
     List,
+    Monitor,
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
@@ -107,6 +144,7 @@ pub enum Response {
     Upgrade(UpgradeResponse),
     List(Vec<CPE>),
     Error(ErrorResponse),
+    Monitor(Vec<Inform>),
 }
 
 impl Response {

--- a/src/soap.rs
+++ b/src/soap.rs
@@ -18,7 +18,7 @@
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct ID {
     #[serde(rename = "$text")]
     pub text: String,
@@ -28,13 +28,13 @@ pub struct ID {
     must_understand: u32,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct Header {
     #[serde(rename(serialize = "cwmp:ID", deserialize = "ID"))]
     pub id: ID,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct DeviceId {
     #[serde(rename = "Manufacturer")]
     pub manufacturer: String,
@@ -49,7 +49,7 @@ pub struct DeviceId {
     pub serial_number: String,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct EventStruct {
     #[serde(rename = "EventCode")]
     pub event_code: String,
@@ -58,7 +58,7 @@ pub struct EventStruct {
     pub command_key: String,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct Event {
     #[serde(rename = "EventStruct")]
     #[serde(default)]
@@ -76,7 +76,7 @@ impl Event {
     }
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct Value {
     #[serde(rename(serialize = "@xsi:type", deserialize = "@type"))]
     #[serde(default)]
@@ -87,7 +87,7 @@ pub struct Value {
     pub text: String,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct ParameterValue {
     #[serde(rename = "Name")]
     pub name: String,
@@ -108,7 +108,7 @@ impl ParameterValue {
     }
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct ParameterList {
     #[serde(rename(serialize = "@soap:arrayType", deserialize = "@arrayType"))]
     #[serde(default)]
@@ -132,7 +132,7 @@ impl ParameterList {
     }
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct Inform {
     #[serde(rename = "DeviceId")]
     pub device_id: DeviceId,
@@ -146,7 +146,7 @@ pub struct Inform {
     pub parameter_list: ParameterList,
 }
 
-#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct InformResponse {
     #[serde(rename = "MaxEnvelopes")]
     pub max_envelopes: u32,
@@ -158,7 +158,7 @@ impl Default for InformResponse {
     }
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct GetParameterNames {
     #[serde(rename = "ParameterPath")]
     #[serde(default)]
@@ -169,7 +169,7 @@ pub struct GetParameterNames {
     pub next_level: u8,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct ParameterInfoStruct {
     #[serde(rename = "Name")]
     #[serde(default)]
@@ -180,21 +180,21 @@ pub struct ParameterInfoStruct {
     pub writable: u8,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct ParameterListInfo {
     #[serde(rename = "ParameterInfoStruct")]
     #[serde(default)]
     pub parameter_info: Vec<ParameterInfoStruct>,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct GetParameterNamesResponse {
     #[serde(rename = "ParameterList")]
     #[serde(default)]
     pub parameter_list: ParameterListInfo,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct ParameterNames {
     #[serde(rename = "@soap:arrayType")]
     #[serde(default)]
@@ -204,7 +204,7 @@ pub struct ParameterNames {
     pub string: Vec<String>,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct GetParameterValues {
     #[serde(rename = "ParameterNames")]
     #[serde(default)]
@@ -224,14 +224,14 @@ impl GetParameterValues {
     }
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct GetParameterValuesResponse {
     #[serde(rename = "ParameterList")]
     #[serde(default)]
     pub parameter_list: ParameterList,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct SetParameterValues {
     #[serde(rename = "ParameterList")]
     pub parameter_list: ParameterList,
@@ -254,13 +254,13 @@ impl SetParameterValues {
     }
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct SetParameterValuesResponse {
     #[serde(rename = "Status")]
     pub status: i32,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct AddObject {
     #[serde(rename = "ObjectName")]
     pub object_name: String,
@@ -269,7 +269,7 @@ pub struct AddObject {
     pub parameter_key: u64,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct AddObjectResponse {
     #[serde(rename = "InstanceNumber")]
     pub instance_number: u32,
@@ -277,7 +277,7 @@ pub struct AddObjectResponse {
     pub status: i32,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct DeleteObject {
     #[serde(rename = "ObjectName")]
     pub object_name: String,
@@ -286,13 +286,13 @@ pub struct DeleteObject {
     pub parameter_key: u64,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct DeleteObjectResponse {
     #[serde(rename = "Status")]
     pub status: i32,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct Download {
     #[serde(rename = "CommandKey")]
     pub command_key: Value,
@@ -424,7 +424,7 @@ impl Download {
     }
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct DownloadResponse {
     #[serde(rename = "Status")]
     pub status: String,
@@ -436,7 +436,7 @@ pub struct DownloadResponse {
     pub complete_time: String,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct TransferComplete {
     #[serde(rename = "CommandKey")]
     pub command_key: String,
@@ -451,10 +451,10 @@ pub struct TransferComplete {
     pub complete_time: String,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct TransferCompleteResponse {}
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct Reboot {
     #[serde(rename = "CommandKey")]
     pub command_key: Value,
@@ -471,10 +471,10 @@ impl Reboot {
     }
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct RebootResponse {}
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct CwmpFault {
     #[serde(rename = "FaultCode")]
     #[serde(default)]
@@ -485,14 +485,14 @@ pub struct CwmpFault {
     pub faultstring: Value,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct SoapFaultDetail {
     #[serde(rename(serialize = "cwmp:Fault", deserialize = "Fault"))]
     #[serde(default)]
     pub cwmpfault: CwmpFault,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct SoapFault {
     #[serde(rename = "faultcode")]
     #[serde(default)]
@@ -507,7 +507,7 @@ pub struct SoapFault {
     pub detail: SoapFaultDetail,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Kind {
     Inform,
     InformResponse,
@@ -531,7 +531,7 @@ pub enum Kind {
     Unknown,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct Body {
     #[serde(rename = "Inform")]
     #[serde(default)]
@@ -637,7 +637,7 @@ pub struct Body {
     pub fault: Vec<SoapFault>,
 }
 
-#[derive(Debug, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(rename(serialize = "soapenv:Envelope", deserialize = "Envelope"))]
 pub struct Envelope {
     #[serde(rename = "@xmlns:soap")]


### PR DESCRIPTION
The monitor command allow to subscribe to any INFORM notifications received by the ACS. It may be used as a base to implement external application to auto-configure CPEs.