### PR TITLE
added option for disabling authentication to ACS

### DIFF
--- a/src/acs.rs
+++ b/src/acs.rs
@@ -200,6 +200,7 @@ impl Acs {
                 identity_password: String::from("ACSRS"),
                 secure_address: String::from("[::0]:8443"),
                 management_address: String::from("127.0.0.1:8000"),
+                noauth: false
             },
             basicauth: Self::basicauth(&username, &password),
             cpe_list: HashMap::new(),

--- a/src/db.rs
+++ b/src/db.rs
@@ -38,6 +38,7 @@ pub struct AcsConfig {
     pub secure_address: String,
     pub unsecure_address: String,
     pub management_address: String,
+    pub noauth: bool,
 }
 
 #[derive(Debug, PartialEq, Default, Deserialize, Serialize)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -432,9 +432,11 @@ impl TR069Session {
         req: &mut Request<IncomingBody>,
     ) -> Result<Response<Full<Bytes>>> {
         self.counter += 1;
-
-        if let Some(reply) = self.authorization_error(req).await {
-            return reply;
+        let noauth = self.acs.read().await.config.noauth;
+        if !noauth {
+            if let Some(reply) = self.authorization_error(req).await {
+                return reply;
+            }
         }
 
         let command = utils::req_path(req, 1);


### PR DESCRIPTION
Some devices have isssues with basic authentication to ACS.
With such scenario access to ACS is protected by some firewall and ACS accepts any incoming requests from CPE's without basic authentication.
This pull provides additional option for disabling authentication CPE -> ACS.